### PR TITLE
Bump Spike Interface and fix probe name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "antspyx>=0.4.2",
     "iblatlas",
     "one-api>=2.6.0",
-    "spikeinterface[full]>=0.101.2",
+    "spikeinterface[full]>=0.103.0",
     "tqdm>=4.66.1",
     "wavpack-numcodecs",
     "numpy==2.0.1",

--- a/src/aind_ephys_ibl_gui_conversion/ephys.py
+++ b/src/aind_ephys_ibl_gui_conversion/ephys.py
@@ -92,7 +92,7 @@ def extract_spikes(  # noqa: C901
     )
 
     neuropix_streams = [s for s in stream_names if "Neuropix" in s]
-    probe_names = [s.split(".")[1].split("_")[0] for s in neuropix_streams]
+    probe_names = [s.split(".")[1].split("-")[0] for s in neuropix_streams]
 
     for idx, stream_name in enumerate(neuropix_streams):
         analyzer_mappings = []
@@ -1012,7 +1012,7 @@ def extract_continuous(  # noqa: C901
 
         print(stream_name)
 
-        probe_name = stream_name.split(".")[1].split("_")[0]
+        probe_name = stream_name.split(".")[1].split("-")[0]
 
         output_folder = Path(results_folder) / probe_name
 


### PR DESCRIPTION
This PR attempts to bump spike interface and fix getting the probe name for the output folder so that the data is saved in one single folder