### PR TITLE
Yb flexible recording number

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,5 @@
 """Configuration file for the Sphinx documentation builder."""
+
 #
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html

--- a/src/aind_ephys_ibl_gui_conversion/__init__.py
+++ b/src/aind_ephys_ibl_gui_conversion/__init__.py
@@ -1,2 +1,3 @@
 """Init package"""
+
 __version__ = "0.0.0"

--- a/src/aind_ephys_ibl_gui_conversion/ephys.py
+++ b/src/aind_ephys_ibl_gui_conversion/ephys.py
@@ -61,7 +61,7 @@ def extract_spikes(  # noqa: C901
         300 seconds (5 minutes).
 
     recording_number: int, optional, default = 1
-        Which recording to use for analysis. 
+        Which recording to use for analysis.
         This will almost always be equal to 1,
         except in rare cases.
         

--- a/src/aind_ephys_ibl_gui_conversion/ephys.py
+++ b/src/aind_ephys_ibl_gui_conversion/ephys.py
@@ -102,6 +102,10 @@ def extract_spikes(  # noqa: C901
     probe_names = [s.split(".")[1].split("-")[0] for s in neuropix_streams]
 
     for idx, stream_name in enumerate(neuropix_streams):
+        # Hack to force quad_base only. remove later!
+        if ("-1" not in stream_name) or ("-2" not in stream_name) or ("-3" not in stream_name) or ("-4" not in stream_name):
+            continue
+        
         analyzer_mappings = []
         num_shanks = 0
         shank_glob = tuple(postprocessed_folder.glob(f"*{stream_name}*group*"))
@@ -975,6 +979,10 @@ def extract_continuous(  # noqa: C901
         if "LFP" in stream_name:
             continue
 
+        # Hack to force quad_base only. remove later!
+        if ("-1" not in stream_name) or ("-2" not in stream_name) or ("-3" not in stream_name) or ("-4" not in stream_name):
+            continue
+            
         if stream_name in recording_mappings:
             min_samples = min(
                 [

--- a/src/aind_ephys_ibl_gui_conversion/ephys.py
+++ b/src/aind_ephys_ibl_gui_conversion/ephys.py
@@ -99,7 +99,7 @@ def extract_spikes(  # noqa: C901
     )
 
     neuropix_streams = [s for s in stream_names if "Neuropix" in s]
-    probe_names = [s.split(".")[1].split("-AP")[0] for s in neuropix_streams]
+    probe_names = [s.split(".")[1].split("-")[0] for s in neuropix_streams]
 
     for idx, stream_name in enumerate(neuropix_streams):
         analyzer_mappings = []
@@ -1027,7 +1027,7 @@ def extract_continuous(  # noqa: C901
 
         print(stream_name)
 
-        probe_name = stream_name.split(".")[1].split("-AP")[0]
+        probe_name = stream_name.split(".")[1].split("-")[0]
 
         output_folder = Path(results_folder) / probe_name
 

--- a/src/aind_ephys_ibl_gui_conversion/ephys.py
+++ b/src/aind_ephys_ibl_gui_conversion/ephys.py
@@ -64,7 +64,6 @@ def extract_spikes(  # noqa: C901
         Which recording to use for analysis.
         This will almost always be equal to 1,
         except in rare cases.
-        
     Returns
     -------
     None

--- a/src/aind_ephys_ibl_gui_conversion/ephys.py
+++ b/src/aind_ephys_ibl_gui_conversion/ephys.py
@@ -125,7 +125,7 @@ def extract_spikes(  # noqa: C901
             for shank_index in range(num_shanks):
                 analyzer_folder = (
                     postprocessed_folder / f"experiment1_{stream_name}_"
-                    f"recording1_group{shank_index}.zarr"
+                    f"recording{recording_number}_group{shank_index}.zarr"
                 )
 
                 if analyzer_folder.is_dir():
@@ -133,7 +133,7 @@ def extract_spikes(  # noqa: C901
                 else:
                     analyzer_folder = (
                         postprocessed_folder / f"experiment1_{stream_name}_"
-                        f"recording1_group{shank_index}"
+                        f"recording{recording_number}_group{shank_index}"
                     )
                     if not analyzer_folder.exists():
                         with open(
@@ -156,14 +156,14 @@ def extract_spikes(  # noqa: C901
         else:
             analyzer_folder = (
                 postprocessed_folder
-                / f"experiment1_{stream_name}_recording1.zarr"
+                / f"experiment1_{stream_name}_recording{recording_number}.zarr"
             )
             if analyzer_folder.is_dir():
                 analyzer = si.load_sorting_analyzer(analyzer_folder)
             else:
                 analyzer_folder = (
                     postprocessed_folder
-                    / f"experiment1_{stream_name}_recording1"
+                    / f"experiment1_{stream_name}_recording{recording_number}"
                 )
                 if not analyzer_folder.exists():
                     with open(output_folder / "sorting_error.txt", "w") as f:

--- a/src/aind_ephys_ibl_gui_conversion/ephys.py
+++ b/src/aind_ephys_ibl_gui_conversion/ephys.py
@@ -34,7 +34,7 @@ MAX_TIMESTAMPS_DEVIATION_MS = 1
 
 
 def extract_spikes(  # noqa: C901
-    sorting_folder, results_folder, min_duration_secs: int = 300,recording_number = 1,
+    sorting_folder, results_folder, min_duration_secs: int = 300, recording_number = 1,
 ):
     """
     Extract spike data from a sorting folder and

--- a/src/aind_ephys_ibl_gui_conversion/ephys.py
+++ b/src/aind_ephys_ibl_gui_conversion/ephys.py
@@ -102,10 +102,6 @@ def extract_spikes(  # noqa: C901
     probe_names = [s.split(".")[1].split("-")[0] for s in neuropix_streams]
 
     for idx, stream_name in enumerate(neuropix_streams):
-        # Hack to force quad_base only. remove later!
-        if ("-1" not in stream_name) or ("-2" not in stream_name) or ("-3" not in stream_name) or ("-4" not in stream_name):
-            continue
-        
         analyzer_mappings = []
         num_shanks = 0
         shank_glob = tuple(postprocessed_folder.glob(f"*{stream_name}*group*"))
@@ -977,10 +973,6 @@ def extract_continuous(  # noqa: C901
 
     for stream_name, main_recordings_streams in main_recordings.items():
         if "LFP" in stream_name:
-            continue
-
-        # Hack to force quad_base only. remove later!
-        if ("-1" not in stream_name) or ("-2" not in stream_name) or ("-3" not in stream_name) or ("-4" not in stream_name):
             continue
             
         if stream_name in recording_mappings:

--- a/src/aind_ephys_ibl_gui_conversion/ephys.py
+++ b/src/aind_ephys_ibl_gui_conversion/ephys.py
@@ -99,7 +99,9 @@ def extract_spikes(  # noqa: C901
     )
 
     neuropix_streams = [s for s in stream_names if "Neuropix" in s]
-    probe_names = [s.split(".")[1].split("-")[0] for s in neuropix_streams]
+    probe_names = [s.split(".")[1].split("_")[0] for s in neuropix_streams]
+
+    print("Probe names",probe_names)
 
     for idx, stream_name in enumerate(neuropix_streams):
         analyzer_mappings = []
@@ -1027,7 +1029,8 @@ def extract_continuous(  # noqa: C901
 
         print(stream_name)
 
-        probe_name = stream_name.split(".")[1].split("-")[0]
+        probe_name = stream_name.split(".")[1].split("_")[0]
+        print(probe_name)
 
         output_folder = Path(results_folder) / probe_name
 

--- a/src/aind_ephys_ibl_gui_conversion/ephys.py
+++ b/src/aind_ephys_ibl_gui_conversion/ephys.py
@@ -960,7 +960,12 @@ def extract_continuous(  # noqa: C901
             ecephys_compressed_folder_surface,
             min_duration_secs=min_duration_secs,
         )
-
+        
+    last_slice = {}
+    for ii,key in enumerate(main_recordings.keys()):
+        last_slice[key] = [x.select_segments(x.get_num_segments()-1) for x in main_recordings[key]]
+    main_recordings = last_slice
+    
     for stream_name, main_recordings_streams in main_recordings.items():
         if "LFP" in stream_name:
             continue

--- a/src/aind_ephys_ibl_gui_conversion/ephys.py
+++ b/src/aind_ephys_ibl_gui_conversion/ephys.py
@@ -34,7 +34,7 @@ MAX_TIMESTAMPS_DEVIATION_MS = 1
 
 
 def extract_spikes(  # noqa: C901
-    sorting_folder, results_folder, min_duration_secs: int = 300
+    sorting_folder, results_folder, min_duration_secs: int = 300,recording_number = 1,
 ):
     """
     Extract spike data from a sorting folder and
@@ -60,6 +60,11 @@ def extract_spikes(  # noqa: C901
         long will be processed. The default value is
         300 seconds (5 minutes).
 
+    recording_number: int,optional, default = 1
+        Which recording to use for analysis. 
+        This will almost always be equal to 1,
+        except in rare cases.
+        
     Returns
     -------
     None

--- a/src/aind_ephys_ibl_gui_conversion/ephys.py
+++ b/src/aind_ephys_ibl_gui_conversion/ephys.py
@@ -34,7 +34,10 @@ MAX_TIMESTAMPS_DEVIATION_MS = 1
 
 
 def extract_spikes(  # noqa: C901
-    sorting_folder, results_folder, min_duration_secs: int = 300, recording_number = 1,
+    sorting_folder,
+    results_folder,
+    min_duration_secs: int = 300,
+    recording_number=1,
 ):
     """
     Extract spike data from a sorting folder and
@@ -959,12 +962,15 @@ def extract_continuous(  # noqa: C901
             ecephys_compressed_folder_surface,
             min_duration_secs=min_duration_secs,
         )
-        
+
     last_slice = {}
     for ii, key in enumerate(main_recordings.keys()):
-        last_slice[key] = [x.select_segments(x.get_num_segments() - 1) for x in main_recordings[key]]
+        last_slice[key] = [
+            x.select_segments(x.get_num_segments() - 1)
+            for x in main_recordings[key]
+        ]
     main_recordings = last_slice
-    
+
     for stream_name, main_recordings_streams in main_recordings.items():
         if "LFP" in stream_name:
             continue

--- a/src/aind_ephys_ibl_gui_conversion/ephys.py
+++ b/src/aind_ephys_ibl_gui_conversion/ephys.py
@@ -60,7 +60,7 @@ def extract_spikes(  # noqa: C901
         long will be processed. The default value is
         300 seconds (5 minutes).
 
-    recording_number: int, optional, default = 1
+    recording_number: int, optional, default=1
         Which recording to use for analysis.
         This will almost always be equal to 1,
         except in rare cases.

--- a/src/aind_ephys_ibl_gui_conversion/ephys.py
+++ b/src/aind_ephys_ibl_gui_conversion/ephys.py
@@ -60,7 +60,7 @@ def extract_spikes(  # noqa: C901
         long will be processed. The default value is
         300 seconds (5 minutes).
 
-    recording_number: int,optional, default = 1
+    recording_number: int, optional, default = 1
         Which recording to use for analysis. 
         This will almost always be equal to 1,
         except in rare cases.

--- a/src/aind_ephys_ibl_gui_conversion/ephys.py
+++ b/src/aind_ephys_ibl_gui_conversion/ephys.py
@@ -961,8 +961,8 @@ def extract_continuous(  # noqa: C901
         )
         
     last_slice = {}
-    for ii,key in enumerate(main_recordings.keys()):
-        last_slice[key] = [x.select_segments(x.get_num_segments()-1) for x in main_recordings[key]]
+    for ii, key in enumerate(main_recordings.keys()):
+        last_slice[key] = [x.select_segments(x.get_num_segments() - 1) for x in main_recordings[key]]
     main_recordings = last_slice
     
     for stream_name, main_recordings_streams in main_recordings.items():

--- a/src/aind_ephys_ibl_gui_conversion/ephys.py
+++ b/src/aind_ephys_ibl_gui_conversion/ephys.py
@@ -97,7 +97,7 @@ def extract_spikes(  # noqa: C901
     )
 
     neuropix_streams = [s for s in stream_names if "Neuropix" in s]
-    probe_names = [s.split(".")[1].split("-")[0] for s in neuropix_streams]
+    probe_names = [s.split(".")[1].split("-AP")[0] for s in neuropix_streams]
 
     for idx, stream_name in enumerate(neuropix_streams):
         analyzer_mappings = []
@@ -1022,7 +1022,7 @@ def extract_continuous(  # noqa: C901
 
         print(stream_name)
 
-        probe_name = stream_name.split(".")[1].split("-")[0]
+        probe_name = stream_name.split(".")[1].split("-AP")[0]
 
         output_folder = Path(results_folder) / probe_name
 

--- a/src/aind_ephys_ibl_gui_conversion/ephys.py
+++ b/src/aind_ephys_ibl_gui_conversion/ephys.py
@@ -99,7 +99,7 @@ def extract_spikes(  # noqa: C901
     )
 
     neuropix_streams = [s for s in stream_names if "Neuropix" in s]
-    probe_names = [s.split(".")[1].split("_")[0] for s in neuropix_streams]
+    probe_names = [s.split(".")[1].split("_")[0].split("-AP")[0] for s in neuropix_streams]
 
     print("Probe names",probe_names)
 
@@ -1029,7 +1029,7 @@ def extract_continuous(  # noqa: C901
 
         print(stream_name)
 
-        probe_name = stream_name.split(".")[1].split("_")[0]
+        probe_name = stream_name.split(".")[1].split("_")[0].split("-AP")[0]
         print(probe_name)
 
         output_folder = Path(results_folder) / probe_name

--- a/src/aind_ephys_ibl_gui_conversion/histology.py
+++ b/src/aind_ephys_ibl_gui_conversion/histology.py
@@ -1,6 +1,7 @@
 """
 Functions to process histology
 """
+
 import json
 import os
 


### PR DESCRIPTION
Updates to the continuous and spike extraction. Specifically, changes allow for multiple recording segments (separate from multiple experiments). If multiple recordings are selected continuous extraction will automatically use the last one. Spike extraction has recording number input that allows for selection.

In addition, file name parsing has been updated to allow Quad base recordings with a "-" in the name (files now split on "-AP"). 