### PR TITLE
Try to fix rms and adds LFP correlation [WIP]

### DIFF
--- a/src/aind_ephys_ibl_gui_conversion/ephys.py
+++ b/src/aind_ephys_ibl_gui_conversion/ephys.py
@@ -647,10 +647,8 @@ def get_stream_mappings(
     freq_max : float, optional
         Upper cutoff frequency (Hz) for LFP bandpass filtering.
         Defaults to 300 Hz.
-    decimation_factor : int, optional
-        Downsampling factor for LFP streams
-        (used only for Neuropixels 2.0 probes).
-        Defaults to 24.
+    target_sample_rate : float
+        The target sample rate to downsample to (only used for 2.0 probes).
 
     Returns
     -------

--- a/src/aind_ephys_ibl_gui_conversion/ephys.py
+++ b/src/aind_ephys_ibl_gui_conversion/ephys.py
@@ -1180,7 +1180,7 @@ def process_raw_data(
         )
 
         save_lfp_correlation(
-            recording_combined,
+            main_recording,
             output_folder,
             lfp_correlation_min_secs,
             lfp_correlation_num_bins,
@@ -1327,6 +1327,7 @@ def extract_continuous(
 
     logging.info(
         "Looking at AP recordings, "
+        f"{tuple(main_recordings_ap.keys())}"
         "will concatenate if surface recordings are present"
     )
     for stream_name_ap in main_recordings_ap:
@@ -1367,6 +1368,7 @@ def extract_continuous(
 
     logging.info(
         "Looking at LFP recordings "
+        f"{tuple(main_recordings_lfp.keys())}"
         "will concatenate if surface recordings are present"
     )
     for stream_name_lfp in main_recordings_lfp:

--- a/src/aind_ephys_ibl_gui_conversion/ephys.py
+++ b/src/aind_ephys_ibl_gui_conversion/ephys.py
@@ -1047,8 +1047,11 @@ def save_lfp_correlation(
         band_corrs[band] = np.nanmean(np.stack(band_corrs[band]), axis=0)
 
     # gui requires this folder
-    output_folder.mkdir("band_corr", exist_ok=True)
     folder_to_save = output_folder / "band_corr"
+    folder_to_save.mkdir(exist_ok=True)
+    logging.info(
+        f"Saving LFP correlation to folder {folder_to_save}"
+    )
     if tag is None:
         for band, corr in band_corrs.items():
             np.save(folder_to_save / f"{band}_mean_corr.npy", corr)

--- a/src/aind_ephys_ibl_gui_conversion/ephys.py
+++ b/src/aind_ephys_ibl_gui_conversion/ephys.py
@@ -553,10 +553,8 @@ def process_lfp_stream(
         recording_lfp = spre.decimate(
             recording_lfp_bandpass, decimation_factor=decimation_factor
         )
-    
-    logging.info(
-        "Applying cmr to lfp recording"
-    )
+
+    logging.info("Applying cmr to lfp recording")
     return spre.common_reference(
         recording_lfp, reference="global", operator="median"
     )
@@ -1047,8 +1045,8 @@ def save_lfp_correlation(
     # average across windows
     for band in band_corrs:
         band_corrs[band] = np.nanmean(np.stack(band_corrs[band]), axis=0)
-    
-    # gui requires this folder 
+
+    # gui requires this folder
     output_folder.mkdir("band_corr", exist_ok=True)
     folder_to_save = output_folder / "band_corr"
     if tag is None:

--- a/src/aind_ephys_ibl_gui_conversion/ephys.py
+++ b/src/aind_ephys_ibl_gui_conversion/ephys.py
@@ -531,7 +531,7 @@ def process_lfp_stream(
             f"with freq min {freq_min} "
             f"and freq max {freq_max}"
         )
-        return spre.bandpass_filter(
+        recording_lfp = spre.bandpass_filter(
             recording, freq_min=freq_min, freq_max=freq_max
         )
     else:  # 2.0 probe, decimate to 1250
@@ -550,9 +550,16 @@ def process_lfp_stream(
             f"Applying decimation with factor {decimation_factor} "
             f"to target sample rate {target_sample_rate}"
         )
-        return spre.decimate(
+        recording_lfp = spre.decimate(
             recording_lfp_bandpass, decimation_factor=decimation_factor
         )
+    
+    logging.info(
+        "Applying cmr to lfp recording"
+    )
+    return spre.common_reference(
+        recording_lfp, reference="global", operator="median"
+    )
 
 
 def get_neuropixel_lfp_stream(
@@ -990,14 +997,10 @@ def save_lfp_correlation(
         If provided, this string will be included
         in the filenames for the saved metrics.
     """
-    # TODO: Should this be done regardless?
     # Adapted from code from Sue:
     # https://github.com/AllenNeuralDynamics/aind-beh-ephys-analysis/blob/main/code/beh_ephys_analysis/ephys_spatial_feature.py#L583
     start_time_lfp_corr = datetime.now()
-    logging.info("Applying common median referencing")
-    recording = spre.common_reference(
-        recording, reference="global", operator="median"
-    )
+
     bands = {
         "delta": [0.5, 4],
         "theta": [4, 12],
@@ -1044,13 +1047,16 @@ def save_lfp_correlation(
     # average across windows
     for band in band_corrs:
         band_corrs[band] = np.nanmean(np.stack(band_corrs[band]), axis=0)
-
+    
+    # gui requires this folder 
+    output_folder.mkdir("band_corr", exist_ok=True)
+    folder_to_save = output_folder / "band_corr"
     if tag is None:
         for band, corr in band_corrs.items():
-            np.save(output_folder / f"{band}_mean_corr.npy", corr)
+            np.save(folder_to_save / f"{band}_mean_corr.npy", corr)
     else:
         for band, corr in band_corrs.items():
-            np.save(output_folder / f"{band}_{tag}_mean_corr.npy", corr)
+            np.save(folder_to_save / f"{band}_{tag}_mean_corr.npy", corr)
 
     end_time_lfp_corr = datetime.now()
     elapsed_time_lfp_corr = end_time_lfp_corr - start_time_lfp_corr

--- a/src/aind_ephys_ibl_gui_conversion/ephys.py
+++ b/src/aind_ephys_ibl_gui_conversion/ephys.py
@@ -990,6 +990,9 @@ def save_lfp_correlation(
         in the filenames for the saved metrics.
     """
     # TODO: Should this be done regardless?
+    # Adapted from code from Sue:
+    # https://github.com/AllenNeuralDynamics/aind-beh-ephys-analysis/blob/main/code/beh_ephys_analysis/ephys_spatial_feature.py#L583
+    start_time_lfp_corr = datetime.now()
     logging.info("Applying common median referencing")
     recording = spre.common_reference(
         recording, reference="global", operator="median"
@@ -1047,6 +1050,13 @@ def save_lfp_correlation(
     else:
         for band, corr in band_corrs.items():
             np.save(output_folder / f"{band}_{tag}_mean_corr.npy", corr)
+
+    end_time_lfp_corr = datetime.now()
+    elapsed_time_lfp_corr = end_time_lfp_corr - start_time_lfp_corr
+    logging.info(
+        "Elapsed time for lfp correlation:"
+        f"{elapsed_time_lfp_corr.total_seconds():.6f} seconds"
+    )
 
 
 def process_raw_data(

--- a/src/aind_ephys_ibl_gui_conversion/ephys.py
+++ b/src/aind_ephys_ibl_gui_conversion/ephys.py
@@ -767,7 +767,10 @@ def save_rms_and_lfp_spectrum(
         in the filenames for the saved metrics.
 
     """
-    logging.info("Computing rms")
+    logging.info(
+        f"Computing rms with chunk duration {chunk_duration}s "
+        f"and using number of parallel jobs {n_jobs}"
+    )
     start_time_rms = datetime.now()
     rms, rms_times = compute_rms(
         recording, chunk_duration=chunk_duration, n_jobs=n_jobs

--- a/src/aind_ephys_ibl_gui_conversion/ephys.py
+++ b/src/aind_ephys_ibl_gui_conversion/ephys.py
@@ -23,12 +23,12 @@ STREAM_PROBE_REGEX = re.compile(r"^Record Node \d+#[^.]+\.(.+?)(-AP|-LFP)?$")
 T = TypeVar("T")
 
 
-def _merge_main_and_surface_recording_dicts(
+def _merge_seperate_asset_recording_dicts(
     d1: DefaultDict[str, list[T]],
     d2: DefaultDict[str, list[T]],
 ) -> DefaultDict[str, list[T]]:
     """
-    Merge main and surface recordings when surface ephys
+    Merge recordings when surface ephys
     is recorded as a separate data asset.
 
     Keys are expected to overlap; values are concatenated.
@@ -1135,16 +1135,16 @@ def extract_continuous(
 
         # combine this with mappings above for
         # seperate surface finding asset
-        main_recordings_ap = _merge_main_and_surface_recording_dicts(
+        main_recordings_ap = _merge_seperate_asset_recording_dicts(
             main_recordings_ap, main_recordings_separate_ap
         )
-        surface_recordings_ap = _merge_main_and_surface_recording_dicts(
+        surface_recordings_ap = _merge_seperate_asset_recording_dicts(
             surface_recordings_ap, surface_recordings_separate_ap
         )
-        main_recordings_lfp = _merge_main_and_surface_recording_dicts(
+        main_recordings_lfp = _merge_seperate_asset_recording_dicts(
             main_recordings_lfp, main_recordings_separate_lfp
         )
-        surface_recordings_lfp = _merge_main_and_surface_recording_dicts(
+        surface_recordings_lfp = _merge_seperate_asset_recording_dicts(
             surface_recordings_lfp, surface_separate_recordings_lfp
         )
 

--- a/src/aind_ephys_ibl_gui_conversion/ephys.py
+++ b/src/aind_ephys_ibl_gui_conversion/ephys.py
@@ -730,6 +730,7 @@ def save_rms_and_lfp_spectrum(
     recording: si.BaseRecording,
     output_folder: Path,
     target_freq_resolution_psd: float,
+    chunk_duration: float,
     n_jobs: int = 10,
     is_lfp: bool = False,
     tag: Union[str, None] = None,
@@ -747,6 +748,12 @@ def save_rms_and_lfp_spectrum(
 
     target_freq_resolution_psd: float
         Target frequency resolution for PSD in Hz
+    
+    chunk_duration : float
+        Chunk length (in seconds) used for 
+        lazy loading and processingof continuous data. 
+        Longer chunks improve stability for
+        low-frequency (LFP) filtering and spectral estimates.
 
     n_jobs: int, default = 10
         The number of jobs to parallelize rms
@@ -762,7 +769,11 @@ def save_rms_and_lfp_spectrum(
     """
     logging.info("Computing rms")
     start_time_rms = datetime.now()
-    rms, rms_times = compute_rms(recording, n_jobs=n_jobs)
+    rms, rms_times = compute_rms(
+        recording, 
+        chunk_duration=chunk_duration,
+        n_jobs=n_jobs
+    )
     end_time_rms = datetime.now()
     elapsed_time_rms = end_time_rms - start_time_rms
     logging.info(
@@ -791,7 +802,7 @@ def save_rms_and_lfp_spectrum(
         lfp_sample_data = get_random_data_chunks(
             recording,
             num_chunks_per_segment=100,
-            chunk_duration="1s",
+            chunk_duration=chunk_duration,
             concatenated=True,
         )
         fs = recording.sampling_frequency
@@ -951,6 +962,7 @@ def process_raw_data(
     results_folder: str,
     is_lfp: bool,
     target_freq_resolution_psd: float,
+    chunk_duration: float,
 ):
     """
     Processes raw data for a given stream by computing RMS and (if applicable)
@@ -981,6 +993,12 @@ def process_raw_data(
 
     target_freq_resolution_psd: float
         Target frequency resolution for PSD in Hz
+    
+    chunk_duration : float
+        Chunk length (in seconds) used for 
+        lazy loading and processingof continuous data. 
+        Longer chunks improve stability for
+        low-frequency (LFP) filtering and spectral estimates.
 
     """
     probe_name = _stream_to_probe_name(stream_name)
@@ -998,6 +1016,7 @@ def process_raw_data(
             recording_combined,
             output_folder,
             target_freq_resolution_psd,
+            chunk_duration,
             is_lfp=is_lfp,
         )
 
@@ -1021,6 +1040,7 @@ def process_raw_data(
         main_recording,
         output_folder,
         target_freq_resolution_psd,
+        chunk_duration,
         is_lfp=is_lfp,
         tag="Main",
     )
@@ -1036,6 +1056,7 @@ def extract_continuous(
     num_parallel_jobs: int = 10,
     target_sample_rate: float = 1250,
     target_freq_resolution_psd: float = 0.5,
+    chunk_duration: float = 15.0,
 ):
     """
     Extract features from raw data
@@ -1083,6 +1104,12 @@ def extract_continuous(
 
     target_freq_resolution_psd: float, default = 0.5
         Target frequency resolution for PSD in Hz
+    
+    chunk_duration : float, default=15.0
+        Chunk length (in seconds) used for 
+        lazy loading and processingof continuous data. 
+        Longer chunks improve stability for
+        low-frequency (LFP) filtering and spectral estimates.
     """
 
     session_folder = Path(str(sorting_folder).split("_sorted")[0])
@@ -1183,6 +1210,7 @@ def extract_continuous(
             results_folder,
             is_lfp=False,
             target_freq_resolution_psd=target_freq_resolution_psd,
+            chunk_duration=chunk_duration
         )
 
     logging.info(
@@ -1222,4 +1250,5 @@ def extract_continuous(
             results_folder,
             is_lfp=True,
             target_freq_resolution_psd=target_freq_resolution_psd,
+            chunk_duration=chunk_duration
         )

--- a/src/aind_ephys_ibl_gui_conversion/ephys.py
+++ b/src/aind_ephys_ibl_gui_conversion/ephys.py
@@ -954,6 +954,106 @@ def get_main_recording_from_list(
         )
     return max(recordings, key=lambda r: r.get_num_samples())
 
+def save_lfp_correlation(
+    recording: si.BaseRecording,
+    output_folder: Path,
+    lfp_correlation_min_secs: int,
+    lfp_correlation_num_bins: int,
+    tag: Union[str, None] = None,
+):
+    """
+    Saves LFP correlation arrays for frequency bands
+    to the specfied output folder.
+
+    Correlation is done for delta, theta, alpha, beta,
+    and gamma frequency bands.
+
+    Runs decimation and common median referencing before
+    as preprocessing step
+
+    Parameters
+    ----------
+    recording: si.BaseRecording
+        The recording to run correlation on
+
+    output_folder: Path
+        The output folder to save outputs to
+
+    lfp_correlation_min_secs : int
+        Duration (seconds) of data used for LFP correlation.
+
+    lfp_correlation_num_bins : int
+        Number of bins used to compute LFP correlation.
+
+    tag : str or None, optional, default=None
+        An optional tag used to distinguish different outputs.
+        If provided, this string will be included
+        in the filenames for the saved metrics.
+    """
+    # TODO: Should this be done regardless?
+    logging.info(
+        "Applying common median referencing"
+    )
+    recording = spre.common_reference(
+        recording, reference="global", operator="median"
+    )
+    bands = {
+        "delta": [0.5, 4],
+        "theta": [4, 12],
+        "alpha": [12, 30],
+        "beta": [30, 100],
+        "gamma": [100, 300],
+    }
+
+    band_corrs = {band: [] for band in bands}
+    bandpass_filtered_recordings = {}
+    for band, (low_f, high_f) in bands.items():
+        bandpass_filtered_recordings[(band, (low_f, high_f))] = (
+            spre.bandpass_filter(recording, freq_min=low_f, freq_max=high_f)
+        )
+
+    max_time_window = min(
+        lfp_correlation_min_secs, recording.get_duration()
+    )
+    time_frames = np.linspace(
+        0, max_time_window, lfp_correlation_num_bins + 1
+    )
+    time_frames_rec = (
+        time_frames * recording.get_sampling_frequency()
+    ).astype(int)
+
+    logging.info(
+        f"Found list of frames to compute correlation {time_frames_rec}"
+    )
+    # calculate lfp correlation
+    for index in range(len(time_frames_rec) - 1):
+        for band, (low_f, high_f) in bands.items():
+            # bandpass
+            D_band = bandpass_filtered_recordings[(band, (low_f, high_f))]
+            # correlation across channels
+            corr_matrix = np.corrcoef(
+                D_band.get_traces(
+                    start_frame=time_frames_rec[index],
+                    end_frame=time_frames_rec[index + 1],
+                ).T
+            )
+            logging.info(
+                f"Processing LFP correlation for band {band}"
+                f"across frames {time_frames_rec[index]} "
+                f"to {time_frames_rec[index + 1]}"
+            )
+            band_corrs[band].append(corr_matrix)
+
+    # average across windows
+    for band in band_corrs:
+        band_corrs[band] = np.nanmean(np.stack(band_corrs[band]), axis=0)
+
+    if tag is None:
+        for band, corr in band_corrs.items():
+            np.save(output_folder / f"{band}_mean_corr.npy", corr)
+    else:
+        for band, corr in band_corrs.items():
+            np.save(output_folder / f"{band}_{tag}_mean_corr.npy", corr)
 
 def process_raw_data(
     main_recording: si.BaseRecording,
@@ -963,6 +1063,8 @@ def process_raw_data(
     is_lfp: bool,
     target_freq_resolution_psd: float,
     chunk_duration: float,
+    lfp_correlation_min_secs: int,
+    lfp_correlation_num_bins: int,
 ):
     """
     Processes raw data for a given stream by computing RMS and (if applicable)
@@ -999,6 +1101,12 @@ def process_raw_data(
         lazy loading and processingof continuous data. 
         Longer chunks improve stability for
         low-frequency (LFP) filtering and spectral estimates.
+    
+    lfp_correlation_min_secs : int
+        Duration (seconds) of data used for LFP correlation.
+
+    lfp_correlation_num_bins : int
+        Number of bins used to compute LFP correlation.
 
     """
     probe_name = _stream_to_probe_name(stream_name)
@@ -1019,6 +1127,20 @@ def process_raw_data(
             chunk_duration,
             is_lfp=is_lfp,
         )
+
+        if is_lfp:
+            logging.info(
+                "Running LFP correlation band generation "
+                f"on concatenated recording for stream {stream_name}"
+            )
+
+            save_lfp_correlation(
+                recording_combined,
+                output_folder,
+                lfp_correlation_min_secs,
+                lfp_correlation_num_bins,
+            )
+
 
     if recording_combined is not None:
         # need appended channel locations
@@ -1045,6 +1167,20 @@ def process_raw_data(
         tag="Main",
     )
 
+    if is_lfp:
+        logging.info(
+            "Running LFP correlation band generation "
+            f"on main recording for stream {stream_name}"
+        )
+
+        save_lfp_correlation(
+            recording_combined,
+            output_folder,
+            lfp_correlation_min_secs,
+            lfp_correlation_num_bins,
+            tag="Main"
+        )
+
 
 def extract_continuous(
     sorting_folder: Path,
@@ -1057,6 +1193,9 @@ def extract_continuous(
     target_sample_rate: float = 1250,
     target_freq_resolution_psd: float = 0.5,
     chunk_duration: float = 15.0,
+    lfp_correlation_min_secs: int = 600,
+    lfp_correlation_num_bins: int = 5,
+
 ):
     """
     Extract features from raw data
@@ -1110,6 +1249,12 @@ def extract_continuous(
         lazy loading and processingof continuous data. 
         Longer chunks improve stability for
         low-frequency (LFP) filtering and spectral estimates.
+    
+    lfp_correlation_min_secs : int
+        Duration (seconds) of data used for LFP correlation.
+
+    lfp_correlation_num_bins : int
+        Number of bins used to compute LFP correlation.
     """
 
     session_folder = Path(str(sorting_folder).split("_sorted")[0])
@@ -1210,7 +1355,9 @@ def extract_continuous(
             results_folder,
             is_lfp=False,
             target_freq_resolution_psd=target_freq_resolution_psd,
-            chunk_duration=chunk_duration
+            chunk_duration=chunk_duration,
+            lfp_correlation_min_secs=lfp_correlation_min_secs,
+            lfp_correlation_num_bins=lfp_correlation_num_bins
         )
 
     logging.info(
@@ -1250,5 +1397,7 @@ def extract_continuous(
             results_folder,
             is_lfp=True,
             target_freq_resolution_psd=target_freq_resolution_psd,
-            chunk_duration=chunk_duration
+            chunk_duration=chunk_duration,
+            lfp_correlation_min_secs=lfp_correlation_min_secs,
+            lfp_correlation_num_bins=lfp_correlation_num_bins
         )

--- a/src/aind_ephys_ibl_gui_conversion/ephys.py
+++ b/src/aind_ephys_ibl_gui_conversion/ephys.py
@@ -748,10 +748,10 @@ def save_rms_and_lfp_spectrum(
 
     target_freq_resolution_psd: float
         Target frequency resolution for PSD in Hz
-    
+
     chunk_duration : float
-        Chunk length (in seconds) used for 
-        lazy loading and processingof continuous data. 
+        Chunk length (in seconds) used for
+        lazy loading and processingof continuous data.
         Longer chunks improve stability for
         low-frequency (LFP) filtering and spectral estimates.
 
@@ -770,9 +770,7 @@ def save_rms_and_lfp_spectrum(
     logging.info("Computing rms")
     start_time_rms = datetime.now()
     rms, rms_times = compute_rms(
-        recording, 
-        chunk_duration=chunk_duration,
-        n_jobs=n_jobs
+        recording, chunk_duration=chunk_duration, n_jobs=n_jobs
     )
     end_time_rms = datetime.now()
     elapsed_time_rms = end_time_rms - start_time_rms
@@ -954,6 +952,7 @@ def get_main_recording_from_list(
         )
     return max(recordings, key=lambda r: r.get_num_samples())
 
+
 def save_lfp_correlation(
     recording: si.BaseRecording,
     output_folder: Path,
@@ -991,9 +990,7 @@ def save_lfp_correlation(
         in the filenames for the saved metrics.
     """
     # TODO: Should this be done regardless?
-    logging.info(
-        "Applying common median referencing"
-    )
+    logging.info("Applying common median referencing")
     recording = spre.common_reference(
         recording, reference="global", operator="median"
     )
@@ -1012,12 +1009,8 @@ def save_lfp_correlation(
             spre.bandpass_filter(recording, freq_min=low_f, freq_max=high_f)
         )
 
-    max_time_window = min(
-        lfp_correlation_min_secs, recording.get_duration()
-    )
-    time_frames = np.linspace(
-        0, max_time_window, lfp_correlation_num_bins + 1
-    )
+    max_time_window = min(lfp_correlation_min_secs, recording.get_duration())
+    time_frames = np.linspace(0, max_time_window, lfp_correlation_num_bins + 1)
     time_frames_rec = (
         time_frames * recording.get_sampling_frequency()
     ).astype(int)
@@ -1054,6 +1047,7 @@ def save_lfp_correlation(
     else:
         for band, corr in band_corrs.items():
             np.save(output_folder / f"{band}_{tag}_mean_corr.npy", corr)
+
 
 def process_raw_data(
     main_recording: si.BaseRecording,
@@ -1095,13 +1089,13 @@ def process_raw_data(
 
     target_freq_resolution_psd: float
         Target frequency resolution for PSD in Hz
-    
+
     chunk_duration : float
-        Chunk length (in seconds) used for 
-        lazy loading and processingof continuous data. 
+        Chunk length (in seconds) used for
+        lazy loading and processingof continuous data.
         Longer chunks improve stability for
         low-frequency (LFP) filtering and spectral estimates.
-    
+
     lfp_correlation_min_secs : int
         Duration (seconds) of data used for LFP correlation.
 
@@ -1141,7 +1135,6 @@ def process_raw_data(
                 lfp_correlation_num_bins,
             )
 
-
     if recording_combined is not None:
         # need appended channel locations
         # so app can show surface recording locations also
@@ -1178,7 +1171,7 @@ def process_raw_data(
             output_folder,
             lfp_correlation_min_secs,
             lfp_correlation_num_bins,
-            tag="Main"
+            tag="Main",
         )
 
 
@@ -1195,7 +1188,6 @@ def extract_continuous(
     chunk_duration: float = 15.0,
     lfp_correlation_min_secs: int = 600,
     lfp_correlation_num_bins: int = 5,
-
 ):
     """
     Extract features from raw data
@@ -1243,13 +1235,13 @@ def extract_continuous(
 
     target_freq_resolution_psd: float, default = 0.5
         Target frequency resolution for PSD in Hz
-    
+
     chunk_duration : float, default=15.0
-        Chunk length (in seconds) used for 
-        lazy loading and processingof continuous data. 
+        Chunk length (in seconds) used for
+        lazy loading and processingof continuous data.
         Longer chunks improve stability for
         low-frequency (LFP) filtering and spectral estimates.
-    
+
     lfp_correlation_min_secs : int
         Duration (seconds) of data used for LFP correlation.
 
@@ -1357,7 +1349,7 @@ def extract_continuous(
             target_freq_resolution_psd=target_freq_resolution_psd,
             chunk_duration=chunk_duration,
             lfp_correlation_min_secs=lfp_correlation_min_secs,
-            lfp_correlation_num_bins=lfp_correlation_num_bins
+            lfp_correlation_num_bins=lfp_correlation_num_bins,
         )
 
     logging.info(
@@ -1399,5 +1391,5 @@ def extract_continuous(
             target_freq_resolution_psd=target_freq_resolution_psd,
             chunk_duration=chunk_duration,
             lfp_correlation_min_secs=lfp_correlation_min_secs,
-            lfp_correlation_num_bins=lfp_correlation_num_bins
+            lfp_correlation_num_bins=lfp_correlation_num_bins,
         )

--- a/src/aind_ephys_ibl_gui_conversion/ephys.py
+++ b/src/aind_ephys_ibl_gui_conversion/ephys.py
@@ -1010,8 +1010,11 @@ def save_lfp_correlation(
     band_corrs = {band: [] for band in bands}
     bandpass_filtered_recordings = {}
     for band, (low_f, high_f) in bands.items():
+        margin_ms = (1 / low_f) * 3 * 1000
         bandpass_filtered_recordings[(band, (low_f, high_f))] = (
-            spre.bandpass_filter(recording, freq_min=low_f, freq_max=high_f)
+            spre.bandpass_filter(
+                recording, freq_min=low_f, freq_max=high_f, margin_ms=margin_ms
+            )
         )
 
     max_time_window = min(lfp_correlation_min_secs, recording.get_duration())
@@ -1049,9 +1052,7 @@ def save_lfp_correlation(
     # gui requires this folder
     folder_to_save = output_folder / "band_corr"
     folder_to_save.mkdir(exist_ok=True)
-    logging.info(
-        f"Saving LFP correlation to folder {folder_to_save}"
-    )
+    logging.info(f"Saving LFP correlation to folder {folder_to_save}")
     if tag is None:
         for band, corr in band_corrs.items():
             np.save(folder_to_save / f"{band}_mean_corr.npy", corr)
@@ -1205,7 +1206,7 @@ def extract_continuous(
     target_freq_resolution_psd: float = 0.5,
     chunk_duration: float = 15.0,
     lfp_correlation_min_secs: int = 600,
-    lfp_correlation_num_bins: int = 5,
+    lfp_correlation_num_bins: int = 10,
 ):
     """
     Extract features from raw data
@@ -1260,10 +1261,10 @@ def extract_continuous(
         Longer chunks improve stability for
         low-frequency (LFP) filtering and spectral estimates.
 
-    lfp_correlation_min_secs : int
+    lfp_correlation_min_secs : int, default = 600
         Duration (seconds) of data used for LFP correlation.
 
-    lfp_correlation_num_bins : int
+    lfp_correlation_num_bins : int, default = 10
         Number of bins used to compute LFP correlation.
     """
 

--- a/tests/test_ephys.py
+++ b/tests/test_ephys.py
@@ -314,6 +314,7 @@ class TestExtractContinuous(unittest.TestCase):
             main_recording=self.rec_ap,
             recording_combined=None,
             target_freq_resolution_psd=0.5,
+            chunk_duration=3,
             stream_name="Record Node 104#Neuropix-PXI-100.ProbeA-AP",
             results_folder=self.tmpdir,
             is_lfp=False,

--- a/tests/test_ephys.py
+++ b/tests/test_ephys.py
@@ -13,7 +13,7 @@ from spikeinterface.extractors import toy_example
 
 from aind_ephys_ibl_gui_conversion.ephys import (
     _stream_to_probe_name,
-    _merge_main_and_surface_recording_dicts,
+    _merge_seperate_asset_recording_dicts,
     get_concatenated_recordings,
     get_largest_segment_recordings,
     get_main_recording_from_list,
@@ -37,7 +37,7 @@ class TestMergeMainAndSurfaceRecordingDicts(unittest.TestCase):
         d1 = defaultdict(list, {"probeA": [1, 2]})
         d2 = defaultdict(list, {"probeA": [3]})
 
-        merged = _merge_main_and_surface_recording_dicts(d1, d2)
+        merged = _merge_seperate_asset_recording_dicts(d1, d2)
 
         self.assertEqual(merged["probeA"], [1, 2, 3])
 
@@ -51,7 +51,7 @@ class TestMergeMainAndSurfaceRecordingDicts(unittest.TestCase):
         d1 = defaultdict(list, {"probeA": [1]})
         d2 = defaultdict(list, {"probeB": [2]})
 
-        merged = _merge_main_and_surface_recording_dicts(d1, d2)
+        merged = _merge_seperate_asset_recording_dicts(d1, d2)
 
         self.assertEqual(merged["probeA"], [1])
         self.assertEqual(merged["probeB"], [2])
@@ -64,7 +64,7 @@ class TestMergeMainAndSurfaceRecordingDicts(unittest.TestCase):
         d1 = defaultdict(list, {"probeA": [1, 2]})
         d2 = defaultdict(list, {"probeA": [3]})
 
-        merged = _merge_main_and_surface_recording_dicts(d1, d2)
+        merged = _merge_seperate_asset_recording_dicts(d1, d2)
         union = d1 | d2
 
         self.assertEqual(merged["probeA"], [1, 2, 3])
@@ -80,7 +80,7 @@ class TestMergeMainAndSurfaceRecordingDicts(unittest.TestCase):
         d1 = defaultdict(list)
         d2 = defaultdict(list)
 
-        merged = _merge_main_and_surface_recording_dicts(d1, d2)
+        merged = _merge_seperate_asset_recording_dicts(d1, d2)
 
         self.assertIs(merged.default_factory, list)
 

--- a/tests/test_ephys.py
+++ b/tests/test_ephys.py
@@ -315,6 +315,8 @@ class TestExtractContinuous(unittest.TestCase):
             recording_combined=None,
             target_freq_resolution_psd=0.5,
             chunk_duration=3,
+            lfp_correlation_min_secs=10,
+            lfp_correlation_num_bins=3,
             stream_name="Record Node 104#Neuropix-PXI-100.ProbeA-AP",
             results_folder=self.tmpdir,
             is_lfp=False,


### PR DESCRIPTION
Tries to fix the rms issues by exposing a chunk duration parameter that can be passed into `compute_rms` from spike interface. 

Incorporates the LFP correlation which fell off my radar at end of last year: #12 with newly refactored ephys module