### PR TITLE
Fix/si deprecated template metrics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "antspyx>=0.4.2",
     "iblatlas",
     "one-api>=2.6.0",
-    "spikeinterface[full]>=0.104.0",
+    "spikeinterface[full]>=0.103.0",
     "tqdm>=4.66.1",
     "wavpack-numcodecs",
     "numpy",

--- a/src/aind_ephys_ibl_gui_conversion/spikes.py
+++ b/src/aind_ephys_ibl_gui_conversion/spikes.py
@@ -50,7 +50,9 @@ def _patch_si_deprecated_metric_validation() -> None:
 
     def _patched_set_params(self, metric_names=None, **kwargs):
         if metric_names is not None:
-            remapped = [_DEPRECATED_METRIC_RENAMES.get(n, n) for n in metric_names]
+            remapped = [
+                _DEPRECATED_METRIC_RENAMES.get(n, n) for n in metric_names
+            ]
             if remapped != metric_names:
                 logging.warning(
                     f"Remapping deprecated SI metric names: "

--- a/src/aind_ephys_ibl_gui_conversion/spikes.py
+++ b/src/aind_ephys_ibl_gui_conversion/spikes.py
@@ -7,11 +7,70 @@ import numpy as np
 import pandas as pd
 import spikeinterface as si
 import spikeinterface.extractors as se
+from packaging.version import Version
 from spikeinterface.exporters import export_to_phy
 
 from aind_ephys_ibl_gui_conversion.recording_utils import (
     _stream_to_probe_name,
 )
+
+# Metric names that were renamed in spikeinterface >= 0.104
+_DEPRECATED_METRIC_RENAMES = {
+    "peak_to_valley": "peak_to_trough_duration",
+    "peak_trough_ratio": "waveform_ratios",
+    "num_positive_peaks": "waveform_baseline_flatness",
+    "num_negative_peaks": "waveform_baseline_flatness",
+    "velocity_above": "velocity_fits",
+    "velocity_below": "velocity_fits",
+}
+
+
+def _patch_si_deprecated_metric_validation() -> None:
+    """Monkey-patch spikeinterface >= 0.104 to ignore deprecated template
+    metric names when loading legacy waveform extractor folders.
+
+    In Code Ocean the data folders are immutable so we cannot rewrite
+    params.json in place. Instead we patch BaseMetricExtension._set_params,
+    which is where the ValueError is raised for deprecated metric names.
+    The remapping here is intentionally minimal — the full cleanup of metric
+    params keys, velocity sub-params, etc. is handled afterward by
+    ComputeTemplateMetrics._handle_backward_compatibility_on_load.
+    """
+    si_version = Version(si.__version__)
+    if si_version < Version("0.104.0"):
+        return
+
+    try:
+        from spikeinterface.core import analyzer_extension_core as _aec
+
+        original_set_params = _aec.BaseMetricExtension._set_params
+
+        def _patched_set_params(self, metric_names=None, **kwargs):
+            if metric_names is not None:
+                metric_names = [
+                    _DEPRECATED_METRIC_RENAMES.get(n, n)
+                    for n in metric_names
+                ]
+                # Deduplicate (e.g. velocity_above + velocity_below -> velocity_fits)
+                seen = []
+                for n in metric_names:
+                    if n not in seen:
+                        seen.append(n)
+                metric_names = seen
+
+            return original_set_params(self, metric_names=metric_names, **kwargs)
+
+        _aec.BaseMetricExtension._set_params = _patched_set_params
+        logging.info(
+            "Patched spikeinterface deprecated template metric validation."
+        )
+    except Exception as e:
+        logging.warning(
+            f"Could not patch spikeinterface metric validation: {e}"
+        )
+
+
+_patch_si_deprecated_metric_validation()
 
 
 def extract_spikes(  # noqa: C901
@@ -33,6 +92,11 @@ def extract_spikes(  # noqa: C901
     min_duration_secs : int
         Minimum duration (seconds) for spike extraction.
     """
+    # Must be called here as well as module level — this function runs in a
+    # subprocess via concurrent.futures and the module-level patch won't
+    # carry over to the child process.
+    _patch_si_deprecated_metric_validation()
+
     session_folder = Path(str(sorting_folder).split("_sorted")[0])
     scratch_folder = Path("/scratch")
 

--- a/src/aind_ephys_ibl_gui_conversion/spikes.py
+++ b/src/aind_ephys_ibl_gui_conversion/spikes.py
@@ -50,24 +50,22 @@ def _patch_si_deprecated_metric_validation() -> None:
 
     def _patched_set_params(self, metric_names=None, **kwargs):
         if metric_names is not None:
-            metric_names = [
-                _DEPRECATED_METRIC_RENAMES.get(n, n) for n in metric_names
-            ]
-            # Deduplicate(velocity_above + velocity_below -> velocity_fits)
+            remapped = [_DEPRECATED_METRIC_RENAMES.get(n, n) for n in metric_names]
+            if remapped != metric_names:
+                logging.warning(
+                    f"Remapping deprecated SI metric names: "
+                    f"{[n for n in metric_names if n in _DEPRECATED_METRIC_RENAMES]}"
+                )
+            # Deduplicate (e.g. velocity_above + velocity_below -> velocity_fits)
             seen = []
-            for n in metric_names:
+            for n in remapped:
                 if n not in seen:
                     seen.append(n)
             metric_names = seen
 
-        return original_set_params(
-            self, metric_names=metric_names, **kwargs
-        )
+        return original_set_params(self, metric_names=metric_names, **kwargs)
 
     _aec.BaseMetricExtension._set_params = _patched_set_params
-    logging.info(
-        "Patched spikeinterface deprecated template metric validation."
-    )
 
 
 def extract_spikes(  # noqa: C901

--- a/src/aind_ephys_ibl_gui_conversion/spikes.py
+++ b/src/aind_ephys_ibl_gui_conversion/spikes.py
@@ -64,7 +64,7 @@ def _patch_si_deprecated_metric_validation() -> None:
                         ]
                     )
                 )
-            # Deduplicate 
+            # Deduplicate
             # (e.g. velocity_above + velocity_below -> velocity_fits)
             seen = []
             for n in remapped:

--- a/src/aind_ephys_ibl_gui_conversion/spikes.py
+++ b/src/aind_ephys_ibl_gui_conversion/spikes.py
@@ -89,7 +89,7 @@ def extract_spikes(  # noqa: C901
     min_duration_secs : int
         Minimum duration (seconds) for spike extraction.
     """
-    # Must be called here as well as module level — this function runs in a
+    # Must be called here this function runs in a
     # subprocess via concurrent.futures and the module-level patch won't
     # carry over to the child process.
     _patch_si_deprecated_metric_validation()

--- a/src/aind_ephys_ibl_gui_conversion/spikes.py
+++ b/src/aind_ephys_ibl_gui_conversion/spikes.py
@@ -49,6 +49,13 @@ def _patch_si_deprecated_metric_validation() -> None:
     original_set_params = _aec.BaseMetricExtension._set_params
 
     def _patched_set_params(self, metric_names=None, **kwargs):
+        """
+        Remap deprecated SI metric names before validation fires.
+        Intercepts BaseMetricExtension._set_params to
+        translate legacy metric names to their >= 0.104 equivalents,
+        allowing legacy WaveformExtractor
+        folders to load without raising a ValueError.
+        """
         if metric_names is not None:
             remapped = [
                 _DEPRECATED_METRIC_RENAMES.get(n, n) for n in metric_names

--- a/src/aind_ephys_ibl_gui_conversion/spikes.py
+++ b/src/aind_ephys_ibl_gui_conversion/spikes.py
@@ -52,17 +52,18 @@ def _patch_si_deprecated_metric_validation() -> None:
         def _patched_set_params(self, metric_names=None, **kwargs):
             if metric_names is not None:
                 metric_names = [
-                    _DEPRECATED_METRIC_RENAMES.get(n, n)
-                    for n in metric_names
+                    _DEPRECATED_METRIC_RENAMES.get(n, n) for n in metric_names
                 ]
-                # Deduplicate (e.g. velocity_above + velocity_below -> velocity_fits)
+                # Deduplicate(velocity_above + velocity_below -> velocity_fits)
                 seen = []
                 for n in metric_names:
                     if n not in seen:
                         seen.append(n)
                 metric_names = seen
 
-            return original_set_params(self, metric_names=metric_names, **kwargs)
+            return original_set_params(
+                self, metric_names=metric_names, **kwargs
+            )
 
         _aec.BaseMetricExtension._set_params = _patched_set_params
         logging.info(
@@ -72,7 +73,6 @@ def _patch_si_deprecated_metric_validation() -> None:
         logging.warning(
             f"Could not patch spikeinterface metric validation: {e}"
         )
-
 
 
 def extract_spikes(  # noqa: C901

--- a/src/aind_ephys_ibl_gui_conversion/spikes.py
+++ b/src/aind_ephys_ibl_gui_conversion/spikes.py
@@ -16,12 +16,16 @@ from aind_ephys_ibl_gui_conversion.recording_utils import (
 
 # Metric names that were renamed in spikeinterface >= 0.104
 _DEPRECATED_METRIC_RENAMES = {
+    # template metrics
     "peak_to_valley": "peak_to_trough_duration",
     "peak_trough_ratio": "waveform_ratios",
     "num_positive_peaks": "waveform_baseline_flatness",
     "num_negative_peaks": "waveform_baseline_flatness",
     "velocity_above": "velocity_fits",
     "velocity_below": "velocity_fits",
+    # quality metrics
+    "l_ratio": "mahalanobis",
+    "isolation_distance": "mahalanobis",
 }
 
 

--- a/src/aind_ephys_ibl_gui_conversion/spikes.py
+++ b/src/aind_ephys_ibl_gui_conversion/spikes.py
@@ -70,8 +70,6 @@ def _patch_si_deprecated_metric_validation() -> None:
         )
 
 
-_patch_si_deprecated_metric_validation()
-
 
 def extract_spikes(  # noqa: C901
     sorting_folder: Path,

--- a/src/aind_ephys_ibl_gui_conversion/spikes.py
+++ b/src/aind_ephys_ibl_gui_conversion/spikes.py
@@ -55,10 +55,17 @@ def _patch_si_deprecated_metric_validation() -> None:
             ]
             if remapped != metric_names:
                 logging.warning(
-                    f"Remapping deprecated SI metric names: "
-                    f"{[n for n in metric_names if n in _DEPRECATED_METRIC_RENAMES]}"
+                    "Remapping deprecated SI metric names: "
+                    + str(
+                        [
+                            n
+                            for n in metric_names
+                            if n in _DEPRECATED_METRIC_RENAMES
+                        ]
+                    )
                 )
-            # Deduplicate (e.g. velocity_above + velocity_below -> velocity_fits)
+            # Deduplicate 
+            # (e.g. velocity_above + velocity_below -> velocity_fits)
             seen = []
             for n in remapped:
                 if n not in seen:

--- a/src/aind_ephys_ibl_gui_conversion/spikes.py
+++ b/src/aind_ephys_ibl_gui_conversion/spikes.py
@@ -44,35 +44,30 @@ def _patch_si_deprecated_metric_validation() -> None:
     if si_version < Version("0.104.0"):
         return
 
-    try:
-        from spikeinterface.core import analyzer_extension_core as _aec
+    from spikeinterface.core import analyzer_extension_core as _aec
 
-        original_set_params = _aec.BaseMetricExtension._set_params
+    original_set_params = _aec.BaseMetricExtension._set_params
 
-        def _patched_set_params(self, metric_names=None, **kwargs):
-            if metric_names is not None:
-                metric_names = [
-                    _DEPRECATED_METRIC_RENAMES.get(n, n) for n in metric_names
-                ]
-                # Deduplicate(velocity_above + velocity_below -> velocity_fits)
-                seen = []
-                for n in metric_names:
-                    if n not in seen:
-                        seen.append(n)
-                metric_names = seen
+    def _patched_set_params(self, metric_names=None, **kwargs):
+        if metric_names is not None:
+            metric_names = [
+                _DEPRECATED_METRIC_RENAMES.get(n, n) for n in metric_names
+            ]
+            # Deduplicate(velocity_above + velocity_below -> velocity_fits)
+            seen = []
+            for n in metric_names:
+                if n not in seen:
+                    seen.append(n)
+            metric_names = seen
 
-            return original_set_params(
-                self, metric_names=metric_names, **kwargs
-            )
-
-        _aec.BaseMetricExtension._set_params = _patched_set_params
-        logging.info(
-            "Patched spikeinterface deprecated template metric validation."
+        return original_set_params(
+            self, metric_names=metric_names, **kwargs
         )
-    except Exception as e:
-        logging.warning(
-            f"Could not patch spikeinterface metric validation: {e}"
-        )
+
+    _aec.BaseMetricExtension._set_params = _patched_set_params
+    logging.info(
+        "Patched spikeinterface deprecated template metric validation."
+    )
 
 
 def extract_spikes(  # noqa: C901


### PR DESCRIPTION
## Problem

When loading legacy `WaveformExtractor` folders using SI >= 0.104,
a `ValueError` is raised during `load_sorting_analyzer_or_waveforms`. SI 0.104 renamed several
template and quality metrics, but the old names are still stored in `params.json` on disk. The
load path in `_read_old_waveforms_extractor_binary` calls `ext.set_params()` before
`_handle_backward_compatibility_on_load`, so the deprecated name validation fires before SI has
a chance to remap them.

In Code Ocean, data folders are immutable so `params.json` cannot be rewritten in place.

## Solution

Monkey-patch `BaseMetricExtension._set_params` at the start of `extract_spikes` to remap
deprecated metric names before the validation check runs. The patch is applied inside
`extract_spikes` rather than at module level because the function runs in a subprocess via
`concurrent.futures` and module-level patches don't carry over to child processes.

The remapping is intentionally minimal — it only handles the name translation needed to get past
the `ValueError`. The more thorough cleanup of `metric_params` keys (e.g. velocity sub-params)
is left to `_handle_backward_compatibility_on_load`, which runs immediately after.

The patch is a no-op on SI < 0.104 where the old names are still valid.

## Deprecated names remapped

**Template metrics**
- `peak_to_valley` → `peak_to_trough_duration`
- `peak_trough_ratio` → `waveform_ratios`
- `num_positive_peaks` → `waveform_baseline_flatness`
- `num_negative_peaks` → `waveform_baseline_flatness`
- `velocity_above` → `velocity_fits`
- `velocity_below` → `velocity_fits`

**Quality metrics**
- `l_ratio` → `mahalanobis`
- `isolation_distance` → `mahalanobis`

## Testing

Verified end to end — all output files written successfully when loading legacy
`WaveformExtractor` folders with SI >= 0.104. Used this session: **ecephys_805752_2025-10-20_13-10-14**, which had a legacy waveform extractor. All sorted metric files were then written successfully:

<img width="353" height="464" alt="image" src="https://github.com/user-attachments/assets/911ef7b2-e062-48bb-acb2-0d4f446874f5" />

Also ran this session: **ecephys_788655_2025-07-28_12-34-17** which was not a legacy waveform extractor and all output files were written successfully.

