### PR TITLE
fix: use largest segment for multi segment recording

### DIFF
--- a/src/aind_ephys_ibl_gui_conversion/io.py
+++ b/src/aind_ephys_ibl_gui_conversion/io.py
@@ -15,6 +15,7 @@ from aind_ephys_ibl_gui_conversion.metrics import (
 )
 from aind_ephys_ibl_gui_conversion.recording_utils import (
     _stream_to_probe_name,
+    get_largest_segment_recordings,
 )
 from aind_ephys_ibl_gui_conversion.types import (
     BlockMetrics,
@@ -101,6 +102,16 @@ def load_probe_streams(
         except Exception:
             logging.exception(f"[FFT] Failed to load zarr: {zarr_path}")
             raise
+        # Multi-segment recordings (e.g. an experiment with multiple
+        # acquisition starts/stops) must be reduced to a single segment
+        # before any segment-agnostic call like get_duration(). For
+        # alignment we keep the largest segment.
+        if rec.get_num_segments() > 1:
+            (rec,) = get_largest_segment_recordings([rec])
+            logging.info(
+                f"[FFT] Multi-segment recording {zarr_path.name} "
+                "reduced to largest segment"
+            )
         rec.reset_times()
         return item, rec
 


### PR DESCRIPTION
Attempts to address #36. Takes the largest segment if the recording is a multi-segment recording.

Tested on offending session from #36: ecephys_762286_2025-01-23_15-37-17 and it ran all the way.
  
Sample logging output below:
```
INFO:root:[FFT] Multi-segment recording experiment1_Record Node 104#Neuropix-PXI-100.ProbeA-LFP.zarr reduced to largest segment
INFO:root:[FFT] Multi-segment recording experiment1_Record Node 104#Neuropix-PXI-100.ProbeA-AP.zarr reduced to largest segment
```